### PR TITLE
ElasticsearchBulkItemWriter 로깅 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,16 @@ public ItemWriter<Domain> writer() {
 }
 ```
 
+### Logging
+
+```yaml
+logging:
+  level:
+    org:
+      springframework:
+        batch:
+          item:
+            elasticsearch:
+              reader: DEBUG
+              writer: DEBUG
+```

--- a/spring-batch-elasticsearch-reader/src/test/resources/application.yml
+++ b/spring-batch-elasticsearch-reader/src/test/resources/application.yml
@@ -8,3 +8,13 @@ spring:
       password:
       driver-class-name: org.h2.Driver
       jdbc-url: jdbc:h2:mem:testdb;MODE=MYSQL
+
+logging:
+  level:
+    org:
+      springframework:
+        batch:
+          item:
+            elasticsearch:
+              reader: DEBUG
+              writer: DEBUG


### PR DESCRIPTION
Closes #1 ElasticsearchBulkItemWriter 로그 출력 기능 추가
```console
2021-11-15 09:44:51.449 DEBUG 1471 --- [           main] o.s.b.i.e.w.ElasticsearchBulkItemWriter  : Writing 3 items
2021-11-15 09:44:52.434 DEBUG 1471 --- [           main] o.s.b.i.e.w.ElasticsearchBulkItemWriter  : 3 documents created
2021-11-15 09:44:52.435 DEBUG 1471 --- [           main] o.s.b.i.e.w.ElasticsearchBulkItemWriter  : 0 documents updated
```

현재 writer가 처리 중인 데이터의 갯수와 create 또는 update 갯수를 출력합니다.